### PR TITLE
Fix ExceptionGroup traceback filtering of pytest internals #13380

### DIFF
--- a/testing/code/test_excinfo.py
+++ b/testing/code/test_excinfo.py
@@ -1797,6 +1797,9 @@ def _exceptiongroup_common(
             rf"FAILED test_excgroup.py::test - {pre_catch}BaseExceptionGroup: Oops \(2.*"
         )
     result.stdout.re_match_lines(match_lines)
+    # check for traceback filtering of pytest internals
+    result.stdout.no_fnmatch_line("*, line *, in pytest_pyfunc_call")
+    result.stdout.no_fnmatch_line("*, line *, in pytest_runtest_call")
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Edited the test to fail on main branch and was able to fix rather than submitting an issue. See sample output of failing test in comment below for reference.

This fix preserves the existing fallback logic for exception groups https://github.com/pytest-dev/pytest/issues/9159 and adds traceback filtering only.